### PR TITLE
Remove indicator on release

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		6BDF5010362617BF977C978FACE9F2D6 /* UIView+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7340A49AAEBD23E1377E130E1704754 /* UIView+Helper.swift */; };
 		8721685066516E7DD45FAF624E20FA4A /* PullToReachObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F50E2462931C21FD1C045DF30B3121 /* PullToReachObserver.swift */; };
 		90D928F32E48FD7E1AF88DC660AF6B4C /* Pods-PullToReach_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = E81E68051F957BAD83F2569B490576D4 /* Pods-PullToReach_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B4FB710228B4EAE00136603 /* SelectionIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4FB70E228B4D5B00136603 /* SelectionIndicatorView.swift */; };
 		A03D0EEDA623259336B83E7890A66388 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ECF2A2B0720AE923C22BED3192888BE0 /* UIKit.framework */; };
 		C8DBFAD876A2F388F9556491410C5C99 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 40CB39E715FBCDAA142E6513E126200A /* Foundation.framework */; };
 		D1115D670C9C7103406942DFB1BE1FBC /* PullToReach-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 01A4D4E91AAA01CF3FBB654D0D336425 /* PullToReach-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -42,6 +43,7 @@
 		63F6792EFBA3A3456330FD011005453B /* PullToReach.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PullToReach.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		85F50E2462931C21FD1C045DF30B3121 /* PullToReachObserver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PullToReachObserver.swift; path = PullToReach/Classes/PullToReachObserver.swift; sourceTree = "<group>"; };
 		87387298B5A965F4EBE4400FFBB738C8 /* Pods-PullToReach_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-PullToReach_Example.modulemap"; sourceTree = "<group>"; };
+		9B4FB70E228B4D5B00136603 /* SelectionIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SelectionIndicatorView.swift; path = PullToReach/Classes/SelectionIndicatorView.swift; sourceTree = "<group>"; };
 		9C0CEA4D6D67895AF623B0304EC57E86 /* Pods-PullToReach_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-PullToReach_Example-dummy.m"; sourceTree = "<group>"; };
 		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		9E84521803AB19718F498200BE3ED687 /* PullToReach.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PullToReach.xcconfig; sourceTree = "<group>"; };
@@ -126,6 +128,7 @@
 				F538B4842D3617F3A4332B92530ADCA6 /* PullToReach.swift */,
 				85F50E2462931C21FD1C045DF30B3121 /* PullToReachObserver.swift */,
 				E1CB06D9360BF8A22144EB74953F837E /* PullToReachTarget.swift */,
+				9B4FB70E228B4D5B00136603 /* SelectionIndicatorView.swift */,
 				F7340A49AAEBD23E1377E130E1704754 /* UIView+Helper.swift */,
 				5B4CC39E94AD735A4FEBB0FCF9F93966 /* Pod */,
 				4034290FD338E14BBE5D3053B22F9C52 /* Support Files */,
@@ -257,6 +260,9 @@
 				LastSwiftUpdateCheck = 0930;
 				LastUpgradeCheck = 1020;
 				TargetAttributes = {
+					3F4B95AB00ACE29CF24C7435D1D1AF9C = {
+						LastSwiftMigration = 1020;
+					};
 					A3E3C8E94C7A072A97ECA4E31380E96C = {
 						LastSwiftMigration = 1020;
 					};
@@ -312,6 +318,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E1E539C690182A3301850F20F2E5C19C /* PullToReach-dummy.m in Sources */,
+				9B4FB710228B4EAE00136603 /* SelectionIndicatorView.swift in Sources */,
 				236E1562336E6D9E50C5050ADB060E6C /* PullToReach.swift in Sources */,
 				8721685066516E7DD45FAF624E20FA4A /* PullToReachObserver.swift in Sources */,
 				DD873C3F12D9A5D4A09F4AAD4A13F9DB /* PullToReachTarget.swift in Sources */,
@@ -336,6 +343,7 @@
 			baseConfigurationReference = F761C7F386318437EF0D57219F8B2958 /* Pods-PullToReach_Example.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -359,6 +367,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -560,6 +570,7 @@
 			baseConfigurationReference = FB1B8A69FFDA4DD2D149E54C297AFA04 /* Pods-PullToReach_Example.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -583,6 +594,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/PullToReach.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/PullToReach.xcscheme
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A3E3C8E94C7A072A97ECA4E31380E96C"
+               BuildableName = "PullToReach.framework"
+               BlueprintName = "PullToReach"
+               ReferencedContainer = "container:Pods.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "607FACCF1AFB9204008FA782"
+            BuildableName = "PullToReach_Example.app"
+            BlueprintName = "PullToReach_Example"
+            ReferencedContainer = "container:../PullToReach.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "607FACCF1AFB9204008FA782"
+            BuildableName = "PullToReach_Example.app"
+            BlueprintName = "PullToReach_Example"
+            ReferencedContainer = "container:../PullToReach.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A3E3C8E94C7A072A97ECA4E31380E96C"
+            BuildableName = "PullToReach.framework"
+            BlueprintName = "PullToReach"
+            ReferencedContainer = "container:Pods.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/PullToReach.xcodeproj/project.pbxproj
+++ b/Example/PullToReach.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
+		9B4FB70D228B4AC000136603 /* TeamMember.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4FB70C228B4AC000136603 /* TeamMember.swift */; };
 		D69CC6758A7FC75D9D5412F9 /* Pods_PullToReach_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 547CA4005348FFAD0D1F4C56 /* Pods_PullToReach_Example.framework */; };
 		F6FAF4112271B94500664A86 /* AddViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FAF40E2271B94500664A86 /* AddViewController.swift */; };
 		F6FAF4142271B94B00664A86 /* TeamMemberDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FAF4132271B94B00664A86 /* TeamMemberDataSource.swift */; };
@@ -30,6 +31,7 @@
 		607FACDF1AFB9204008FA782 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		7FCD2A828D2DF7DAA5B19E1F /* Pods_PullToReach_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PullToReach_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7FD1CDB93F6FA665FF33BEA0 /* Pods-PullToReach_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PullToReach_Example.release.xcconfig"; path = "Target Support Files/Pods-PullToReach_Example/Pods-PullToReach_Example.release.xcconfig"; sourceTree = "<group>"; };
+		9B4FB70C228B4AC000136603 /* TeamMember.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamMember.swift; sourceTree = "<group>"; };
 		D75CF7F9BC8E2C9EC99AE7B4 /* Pods-PullToReach_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PullToReach_Example.debug.xcconfig"; path = "Target Support Files/Pods-PullToReach_Example/Pods-PullToReach_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		DC06F21EDD0E1F7CC6B26854 /* Pods-PullToReach_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PullToReach_Tests.release.xcconfig"; path = "Target Support Files/Pods-PullToReach_Tests/Pods-PullToReach_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		F6FAF40E2271B94500664A86 /* AddViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddViewController.swift; sourceTree = "<group>"; };
@@ -74,7 +76,7 @@
 			children = (
 				607FACD51AFB9204008FA782 /* AppDelegate.swift */,
 				F6FAF4162271B96200664A86 /* View Controllers */,
-				F6FAF4152271B95A00664A86 /* Data Sources */,
+				F6FAF4152271B95A00664A86 /* Model */,
 				607FACDC1AFB9204008FA782 /* Images.xcassets */,
 				607FACDE1AFB9204008FA782 /* LaunchScreen.xib */,
 				607FACD31AFB9204008FA782 /* Supporting Files */,
@@ -121,12 +123,13 @@
 			path = Pods;
 			sourceTree = "<group>";
 		};
-		F6FAF4152271B95A00664A86 /* Data Sources */ = {
+		F6FAF4152271B95A00664A86 /* Model */ = {
 			isa = PBXGroup;
 			children = (
 				F6FAF4132271B94B00664A86 /* TeamMemberDataSource.swift */,
+				9B4FB70C228B4AC000136603 /* TeamMember.swift */,
 			);
-			name = "Data Sources";
+			name = Model;
 			sourceTree = "<group>";
 		};
 		F6FAF4162271B96200664A86 /* View Controllers */ = {
@@ -263,6 +266,7 @@
 			files = (
 				F6FAF4112271B94500664A86 /* AddViewController.swift in Sources */,
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,
+				9B4FB70D228B4AC000136603 /* TeamMember.swift in Sources */,
 				F6FAF41A2271C79700664A86 /* ProfileViewController.swift in Sources */,
 				F6FAF4142271B94B00664A86 /* TeamMemberDataSource.swift in Sources */,
 				F6FAF4192271C79400664A86 /* TeamMembersViewController.swift in Sources */,

--- a/Example/PullToReach/AddViewController.swift
+++ b/Example/PullToReach/AddViewController.swift
@@ -11,7 +11,13 @@ import PullToReach
 
 class AddViewController: UITableViewController, PullToReach {
 
-    private lazy var refreshBarButtonItem = UIBarButtonItem(image: UIImage(named: "close"), style: .plain, target: self, action: #selector(closeView))
+    // MARK: - Views
+
+    private lazy var refreshBarButtonItem =
+        UIBarButtonItem(image: UIImage(named: "close"), style: .plain,
+                        target: self, action: #selector(closeView))
+
+    // MARK: - Overrides
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Example/PullToReach/AppDelegate.swift
+++ b/Example/PullToReach/AppDelegate.swift
@@ -11,13 +11,16 @@ import UIKit
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    var window: UIWindow?
+    // MARK: - Stored properties
+
+    let window = UIWindow(frame: UIScreen.main.bounds)
+
+    // MARK: - UIApplicationDelegate
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        window = UIWindow(frame: UIScreen.main.bounds)
-        window?.makeKeyAndVisible()
 
-        window?.rootViewController = UINavigationController(rootViewController: TeamMembersViewController())
+        window.rootViewController = UINavigationController(rootViewController: TeamMembersViewController())
+        window.makeKeyAndVisible()
 
         UINavigationBar.appearance().tintColor = .black
         UINavigationBar.appearance().prefersLargeTitles = true

--- a/Example/PullToReach/ProfileViewController.swift
+++ b/Example/PullToReach/ProfileViewController.swift
@@ -12,6 +12,8 @@ import UIKit
 
 class ProfileViewController: UITableViewController, PullToReach {
 
+    // MARK: - Overrides
+
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/Example/PullToReach/TeamMember.swift
+++ b/Example/PullToReach/TeamMember.swift
@@ -1,0 +1,30 @@
+//
+//  TeamMember.swift
+//  PullToReach_Example
+//
+//  Created by Paul Kraft on 14.05.19.
+//  Copyright © 2019 CocoaPods. All rights reserved.
+//
+
+import Foundation
+import UIKit.UIImage
+
+struct TeamMember {
+
+    // MARK: - Stored properties
+
+    let firstName: String
+    let lastName: String
+    let imageName: String
+
+    // MARK: - Computed properties
+
+    var email: String {
+        return "\(firstName.lowercased()).\(lastName.lowercased())@quickbirdstudios.com"
+    }
+
+    var image: UIImage? {
+        return UIImage(named: imageName)
+    }
+
+}

--- a/Example/PullToReach/TeamMemberDataSource.swift
+++ b/Example/PullToReach/TeamMemberDataSource.swift
@@ -11,7 +11,7 @@ import UIKit
 private let allTeamMembers = [
     TeamMember(firstName: "Stefan", lastName: "Kofler", imageName: "Stefan_Kofler"),
     TeamMember(firstName: "Malte", lastName: "Bucksch", imageName: "Malte_Bucksch"),
-    TeamMember(firstName: "Sabastian", lastName: "Sellmair", imageName: "Sebastian_Sellmair"),
+    TeamMember(firstName: "Sebastian", lastName: "Sellmair", imageName: "Sebastian_Sellmair"),
     TeamMember(firstName: "Julian", lastName: "Bissekkou", imageName: "Julian_Bissekkou"),
     TeamMember(firstName: "Klaus", lastName: "Niedermair", imageName: "Klaus_Niedermair"),
     TeamMember(firstName: "Ghulam", lastName: "Nasir", imageName: "Ghulam_Nasir"),

--- a/Example/PullToReach/TeamMemberDataSource.swift
+++ b/Example/PullToReach/TeamMemberDataSource.swift
@@ -8,20 +8,6 @@
 
 import UIKit
 
-struct TeamMember {
-    let firstName: String
-    let lastName: String
-    let imageName: String
-
-    var email: String {
-        return "\(firstName.lowercased()).\(lastName.lowercased())@quickbirdstudios.com"
-    }
-
-    var image: UIImage? {
-        return UIImage(named: imageName)
-    }
-}
-
 private let allTeamMembers = [
     TeamMember(firstName: "Stefan", lastName: "Kofler", imageName: "Stefan_Kofler"),
     TeamMember(firstName: "Malte", lastName: "Bucksch", imageName: "Malte_Bucksch"),
@@ -41,7 +27,11 @@ private let allTeamMembers = [
 
 class TeamMembersDataSource: NSObject, UITableViewDataSource {
 
+    // MARK: - Stored properties
+
     private let teamMembers = allTeamMembers.shuffled()
+
+    // MARK: - UITableViewDataSource
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return teamMembers.count

--- a/Example/PullToReach/TeamMembersViewController.swift
+++ b/Example/PullToReach/TeamMembersViewController.swift
@@ -11,12 +11,26 @@ import UIKit
 
 class TeamMembersViewController: UITableViewController, PullToReach {
 
+    // MARK: - Views
+
+    private lazy var addBarButtonItem =
+        UIBarButtonItem(image: UIImage(named: "add"), style: .plain,
+                        target: self, action: #selector(addItem))
+
+    private lazy var searchBarButtonItem =
+        UIBarButtonItem(image: UIImage(named: "search"), style: .plain,
+                        target: self, action: #selector(searchItems))
+
+    private lazy var refreshBarButtonItem =
+        UIBarButtonItem(image: UIImage(named: "refresh"), style: .plain,
+                        target: self, action: #selector(reloadItems))
+
+    // MARK: - Stored properties
+
     private let searchController = UISearchController(searchResultsController: nil)
     private var dataSource = TeamMembersDataSource()
 
-    private lazy var addBarButtonItem = UIBarButtonItem(image: UIImage(named: "add"), style: .plain, target: self, action: #selector(addItem))
-    private lazy var searchBarButtonItem = UIBarButtonItem(image: UIImage(named: "search"), style: .plain, target: self, action: #selector(searchItems))
-    private lazy var refreshBarButtonItem = UIBarButtonItem(image: UIImage(named: "refresh"), style: .plain, target: self, action: #selector(reloadItems))
+    // MARK: - Overrides
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/PullToReach/Classes/PullToReach.swift
+++ b/PullToReach/Classes/PullToReach.swift
@@ -40,8 +40,6 @@ public extension PullToReach {
             let percent = min(modifiedOffset / maxOffset, 0.99)
             let currentSelectedIndex = Int(percent * CGFloat(affectedTargets.count))
 
-            print(percent, currentSelectedIndex)
-
             if didRelease {
                 affectedTargets[currentSelectedIndex].callSelector()
                 heavyFeedbackGenerator.impactOccurred()

--- a/PullToReach/Classes/PullToReach.swift
+++ b/PullToReach/Classes/PullToReach.swift
@@ -29,6 +29,7 @@ public extension PullToReach {
 
                 for target in affectedTargets {
                     target.applyStyle(isHighlighted: false, highlightColor: highlightColor)
+                    target.removeHighlight()
                 }
 
                 return
@@ -38,6 +39,8 @@ public extension PullToReach {
 
             let percent = min(modifiedOffset / maxOffset, 0.99)
             let currentSelectedIndex = Int(percent * CGFloat(affectedTargets.count))
+
+            print(percent, currentSelectedIndex)
 
             if didRelease {
                 affectedTargets[currentSelectedIndex].callSelector()
@@ -73,11 +76,12 @@ public extension PullToReach {
                              direction: PTRDirection = .rightToLeft,
                              highlightColor: UIColor = UIColor.black.withAlphaComponent(0.1)) {
         let barButtonItems: [UIBarButtonItem]
+
         switch direction {
         case .leftToRight:
-            barButtonItems = (navigationItem.leftBarButtonItems ?? []) + (navigationItem.rightBarButtonItems ?? [])
+            barButtonItems = (navigationItem.leftBarButtonItems ?? []) + (navigationItem.rightBarButtonItems ?? []).reversed()
         case .rightToLeft:
-            barButtonItems = (navigationItem.rightBarButtonItems ?? []) + (navigationItem.leftBarButtonItems ?? [])
+            barButtonItems = (navigationItem.rightBarButtonItems ?? []) + (navigationItem.leftBarButtonItems ?? []).reversed()
         }
 
         activatePullToReach(affectedTargets: barButtonItems, highlightColor: highlightColor)

--- a/PullToReach/Classes/PullToReachObserver.swift
+++ b/PullToReach/Classes/PullToReachObserver.swift
@@ -11,20 +11,30 @@ import UIKit
 @available(iOS 11.0, *)
 class PullToReachObserver: NSObject {
 
-    private var scrollOffsetChanged: ((CGFloat, Bool, Bool) -> Void)!
-    private var scrollView: UIScrollView!
+    // MARK: - Stored properties
+
+    private let scrollOffsetChanged: (CGFloat, Bool, Bool) -> Void
+    private let scrollView: UIScrollView
 
     private var lastOffset: CGFloat = 0
     private var wasTracking: Bool = false
 
-    init(scrollView: UIScrollView, scrollOffsetChanged: @escaping (CGFloat, Bool, Bool) -> Void) {
-        super.init()
+    // MARK: - Init
 
+    init(scrollView: UIScrollView, scrollOffsetChanged: @escaping (CGFloat, Bool, Bool) -> Void) {
         self.scrollOffsetChanged = scrollOffsetChanged
         self.scrollView = scrollView
 
+        super.init()
+
         scrollView.addObserver(self, forKeyPath: #keyPath(UIScrollView.contentOffset), options: .new, context: nil)
     }
+
+    deinit {
+        scrollView.removeObserver(self, forKeyPath: #keyPath(UIScrollView.contentOffset))
+    }
+
+    // MARK: - Overrides
 
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
         guard let scrollView = object as? UIScrollView else { return }
@@ -33,18 +43,14 @@ class PullToReachObserver: NSObject {
             let scrollOffset = -(scrollView.contentOffset.y + scrollView.adjustedContentInset.top)
 
             if wasTracking && !scrollView.isTracking {
-                self.scrollOffsetChanged?(lastOffset, true, false)
+                self.scrollOffsetChanged(lastOffset, true, false)
             } else {
-                self.scrollOffsetChanged?(scrollOffset, false, scrollView.isTracking)
+                self.scrollOffsetChanged(scrollOffset, false, scrollView.isTracking)
             }
 
             self.lastOffset = scrollOffset
             self.wasTracking = scrollView.isTracking
         }
-    }
-
-    deinit {
-        scrollView.removeObserver(self, forKeyPath: #keyPath(UIScrollView.contentOffset))
     }
 
 }

--- a/PullToReach/Classes/SelectionIndicatorView.swift
+++ b/PullToReach/Classes/SelectionIndicatorView.swift
@@ -1,0 +1,10 @@
+//
+//  SelectionIndicatorView.swift
+//  Pods-PullToReach_Example
+//
+//  Created by Paul Kraft on 14.05.19.
+//
+
+import UIKit
+
+class SelectionIndicatorView: UIView {}

--- a/PullToReach/Classes/UIView+Helper.swift
+++ b/PullToReach/Classes/UIView+Helper.swift
@@ -20,4 +20,16 @@ extension UIView {
         }
     }
 
+    func firstSubview<T>(ofType type: T.Type) -> T? {
+        if let self = self as? T { return self }
+
+        for subview in subviews {
+            if let firstSubview = subview.firstSubview(ofType: T.self) {
+                return firstSubview
+            }
+        }
+
+        return nil
+    }
+
 }


### PR DESCRIPTION
In this PR, there are some code style improvements and a way to remove the indicator on release (especially useful, when there is no UIBarbuttonItem selected, but rather the user decided to scroll down again).